### PR TITLE
Fix Rider rebuild failing due to missing Tailwind CSS

### DIFF
--- a/Meyers.Web/Meyers.Web.csproj
+++ b/Meyers.Web/Meyers.Web.csproj
@@ -32,10 +32,11 @@
         <Exec Command="npm run build" WorkingDirectory="$(MSBuildProjectDirectory)" />
     </Target>
 
-    <!-- Clean generated CSS on clean -->
-    <Target Name="CleanTailwindCss" BeforeTargets="Clean">
+    <!-- Clean generated CSS on clean, then immediately regenerate so static asset resolution doesn't fail -->
+    <Target Name="CleanTailwindCss" AfterTargets="Clean">
         <Message Text="Cleaning generated Tailwind CSS..." Importance="high" />
         <Delete Files="$(MSBuildProjectDirectory)/wwwroot/css/app.css" />
+        <Exec Command="npm run build" WorkingDirectory="$(MSBuildProjectDirectory)" />
     </Target>
 
 


### PR DESCRIPTION
CleanTailwindCss ran before Clean, deleting app.css. On rebuild, DefineStaticWebAssets failed because the file was gone before BuildTailwindCss could regenerate it. Now the target runs after Clean and immediately regenerates the CSS.