### PR TITLE
Bump Microsoft packages to 10.0.6 (April 2026 security patch)

### DIFF
--- a/Meyers.Infrastructure/Meyers.Infrastructure.csproj
+++ b/Meyers.Infrastructure/Meyers.Infrastructure.csproj
@@ -6,8 +6,8 @@
 
     <ItemGroup>
         <PackageReference Include="Ical.Net" Version="5.2.1"/>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.5"/>
-        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.5"/>
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.6"/>
+        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.6"/>
     </ItemGroup>
 
     <PropertyGroup>

--- a/Meyers.Test/Meyers.Test.csproj
+++ b/Meyers.Test/Meyers.Test.csproj
@@ -9,7 +9,7 @@
 
     <ItemGroup>
         <PackageReference Include="coverlet.collector" Version="8.0.1"/>
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.5"/>
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.6"/>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0"/>
         <PackageReference Include="xunit" Version="2.9.3"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5"/>

--- a/Meyers.Web/Meyers.Web.csproj
+++ b/Meyers.Web/Meyers.Web.csproj
@@ -8,8 +8,8 @@
 
     <ItemGroup>
         <PackageReference Include="Ical.Net" Version="5.2.1" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.5" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5">
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.6" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.6">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>


### PR DESCRIPTION
Addresses CVE-2026-26171, CVE-2026-32178, CVE-2026-32203, CVE-2026-33116.

Updates Microsoft.EntityFrameworkCore.Sqlite, Microsoft.EntityFrameworkCore.Design, Microsoft.Extensions.Hosting.Abstractions, and Microsoft.AspNetCore.Mvc.Testing from 10.0.5 to 10.0.6.