### PR TITLE
Redesign homepage as a printed menu card

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ Features multi-menu support, responsive design, and automatic caching.
 - `Components/Home.razor`: Multi-menu homepage with custom calendar builder UI
 - `Handlers/`: API endpoints for calendar feeds and menu previews
 - `wwwroot/js/menu-app.js`: Client-side functionality (toggleMenuMode, copyToClipboard, updateWeeklyPreview)
-- `Styles/app.css`: Tailwind CSS v4 configuration
+- `Styles/app.css`: Tailwind CSS v4 configuration and design system
 
 ### Meyers.Test
 
@@ -64,7 +64,7 @@ Features multi-menu support, responsive design, and automatic caching.
 cd Meyers.Web && npm install && cd ..
 dotnet run --project Meyers.Web
 
-# Testing (167 tests total)
+# Testing (220 tests total)
 dotnet test
 
 # Database migrations (note: context is in Infrastructure but migrations run via Web project)
@@ -114,7 +114,9 @@ handlers from triggering expensive scraping operations.
 
 ## Testing
 
-Comprehensive test suite (167 tests) with TestWebApplicationFactory, MockHttpMessageHandler, and real HTML fixtures.
+Comprehensive test suite (220 tests) with TestWebApplicationFactory, MockHttpMessageHandler, and real HTML fixtures.
+Tests must stay deterministic: production code gets "today" from ITimeZoneService (pinned to fixed fixture dates in
+tests via TestTimeZoneService), never DateTime.Today directly.
 Tests all 6 menu types, web interface, API endpoints, mobile responsiveness, and MapStaticAssets fingerprinting.
 
 ## Important Notes
@@ -124,7 +126,10 @@ Tests all 6 menu types, web interface, API endpoints, mobile responsiveness, and
 - **JS Assets**: Use `@Assets["js/menu-app.js"]` for JavaScript files
 - **Regex**: Always use `GeneratedRegex` attribute
 - **Database**: Repository pattern with optimized single queries in Infrastructure layer
-- **Testing**: Update all tests when adding features (currently 167 tests)
+- **Testing**: Update all tests when adding features (currently 220 tests)
+- **Dates**: Always get "today" via ITimeZoneService (GetCopenhagenDate), never DateTime.Today; tests pin the date
+- **Design**: Light-only "printed menu card" theme; paper/ink/madder palette, Fraunces + IBM Plex Mono (Google Fonts),
+  design tokens and component classes live in `Styles/app.css` (dark: variants are disabled via @custom-variant)
 - **Calendar Events**: All events include 5-minute alarm notifications
 - **Title Cleanup**: CalendarService.CleanupTitle() only adds "..." when actually truncating content
 - **Namespace Updates**: Use Infrastructure namespaces for moved services and repositories

--- a/Meyers.Infrastructure/Services/MenuScrapingService.cs
+++ b/Meyers.Infrastructure/Services/MenuScrapingService.cs
@@ -7,7 +7,10 @@ using Meyers.Core.Utilities;
 
 namespace Meyers.Infrastructure.Services;
 
-public partial class MenuScrapingService(HttpClient httpClient, IMenuRepository menuRepository) : IMenuScrapingService
+public partial class MenuScrapingService(
+    HttpClient httpClient,
+    IMenuRepository menuRepository,
+    ITimeZoneService timeZoneService) : IMenuScrapingService
 {
     private const string Url = "https://meyers.dk/ugens-menuer";
     private static readonly TimeSpan CacheRefreshInterval = TimeSpan.FromHours(6);
@@ -44,8 +47,9 @@ public partial class MenuScrapingService(HttpClient httpClient, IMenuRepository 
     {
         // Get all cached entries from the past week to future two weeks to ensure we don't miss any data
         // Use .Date to ensure we're working with date-only comparisons
-        var startDate = DateTime.Today.AddDays(-7).Date;
-        var endDate = DateTime.Today.AddDays(14).Date;
+        var today = timeZoneService.GetCopenhagenDate();
+        var startDate = today.AddDays(-7).Date;
+        var endDate = today.AddDays(14).Date;
         var cachedEntries = await menuRepository.GetMenusForDateRangeAsync(startDate, endDate);
 
         return cachedEntries.Select(entry => new MenuDay
@@ -104,7 +108,7 @@ public partial class MenuScrapingService(HttpClient httpClient, IMenuRepository 
             var html = await httpClient.GetStringAsync(Url);
             scrapingLog.RequestSuccessful = true;
 
-            var menuDays = ParseNuxtData(html);
+            var menuDays = ParseNuxtData(html, timeZoneService.GetCopenhagenDate());
 
             scrapingLog.ParsingSuccessful = true;
             scrapingLog.NewMenuItemsCount = menuDays.Count;
@@ -144,7 +148,7 @@ public partial class MenuScrapingService(HttpClient httpClient, IMenuRepository 
         }
     }
 
-    internal static List<MenuDay> ParseNuxtData(string html)
+    internal static List<MenuDay> ParseNuxtData(string html, DateTime today)
     {
         // Extract the __NUXT_DATA__ JSON array from the script tag
         var match = NuxtDataRegex().Match(html);
@@ -168,7 +172,7 @@ public partial class MenuScrapingService(HttpClient httpClient, IMenuRepository 
         if (menuDays.Count > 0) return menuDays;
 
         // Fall back to the legacy Sanity menuBlock format
-        return ParseLegacyMenuBlocks(data);
+        return ParseLegacyMenuBlocks(data, today);
     }
 
     /// <summary>
@@ -324,7 +328,7 @@ public partial class MenuScrapingService(HttpClient httpClient, IMenuRepository 
     /// <summary>
     /// Parses the legacy Sanity-based menuBlock format (pre-April 2026).
     /// </summary>
-    private static List<MenuDay> ParseLegacyMenuBlocks(JsonElement[] data)
+    private static List<MenuDay> ParseLegacyMenuBlocks(JsonElement[] data, DateTime today)
     {
         var menuDays = new List<MenuDay>();
 
@@ -367,7 +371,7 @@ public partial class MenuScrapingService(HttpClient httpClient, IMenuRepository 
                 if (weekLabelIdx >= data.Length) continue;
 
                 var weekLabel = data[weekLabelIdx].GetString() ?? "";
-                var weekDates = ParseWeekDates(weekLabel);
+                var weekDates = ParseWeekDates(weekLabel, today);
                 if (weekDates.Count == 0) continue;
 
                 // Resolve days array
@@ -512,9 +516,9 @@ public partial class MenuScrapingService(HttpClient httpClient, IMenuRepository 
 
     /// <summary>
     /// Computes Mon-Fri dates from a week label like "Uge 11".
-    /// Uses ISO 8601 week numbering. Year is inferred from proximity to current date.
+    /// Uses ISO 8601 week numbering. Year is inferred from proximity to the given date.
     /// </summary>
-    internal static List<DateTime> ParseWeekDates(string weekLabel)
+    internal static List<DateTime> ParseWeekDates(string weekLabel, DateTime today)
     {
         var dates = new List<DateTime>();
 
@@ -522,7 +526,7 @@ public partial class MenuScrapingService(HttpClient httpClient, IMenuRepository 
         if (!weekMatch.Success) return dates;
 
         var weekNumber = int.Parse(weekMatch.Groups[1].Value);
-        var year = DetermineYear(weekNumber);
+        var year = DetermineYear(weekNumber, today);
         var monday = ISOWeek.GetYearStart(year).AddDays((weekNumber - 1) * 7);
 
         // Generate Mon-Fri dates
@@ -534,9 +538,8 @@ public partial class MenuScrapingService(HttpClient httpClient, IMenuRepository 
         return dates;
     }
 
-    private static int DetermineYear(int weekNumber)
+    private static int DetermineYear(int weekNumber, DateTime now)
     {
-        var now = DateTime.Today;
         var year = now.Year;
 
         // Handle year boundary: Dec showing week 1-2 = next year, Jan showing week 52+ = previous year

--- a/Meyers.Test/CacheDurationTests.cs
+++ b/Meyers.Test/CacheDurationTests.cs
@@ -23,7 +23,7 @@ public class CacheDurationTests
 
         // We need to create a mock handler to test the private method
         _handler = new CalendarEndpointHandler(
-            null!, null!, null!, options);
+            null!, null!, null!, null!, options);
     }
 
     [Fact]

--- a/Meyers.Test/MenuScrapingServiceTests.cs
+++ b/Meyers.Test/MenuScrapingServiceTests.cs
@@ -10,6 +10,9 @@ namespace Meyers.Test;
 
 public class MenuScrapingServiceTests
 {
+    // Fixed date matching the test fixture data (Mar 9-20, 2026)
+    private static readonly DateTime FixtureToday = new(2026, 3, 9);
+
     private readonly string _testHtmlPath;
 
     public MenuScrapingServiceTests()
@@ -33,7 +36,7 @@ public class MenuScrapingServiceTests
     {
         var mockHttpClient = CreateMockHttpClient(_testHtmlPath);
         var repository = new MenuRepository(context);
-        return new MenuScrapingService(mockHttpClient, repository);
+        return new MenuScrapingService(mockHttpClient, repository, new TestTimeZoneService());
     }
 
     private HttpClient CreateMockHttpClient(string filePath)
@@ -209,7 +212,7 @@ public class MenuScrapingServiceTests
         };
         var httpClient = new HttpClient(mockHandler);
         var repository = new MenuRepository(context);
-        var scrapingService = new MenuScrapingService(httpClient, repository);
+        var scrapingService = new MenuScrapingService(httpClient, repository, new TimeZoneService());
 
         // Act - First call should scrape from website
         var firstResult = await scrapingService.ScrapeMenuAsync();
@@ -239,7 +242,7 @@ public class MenuScrapingServiceTests
         };
         var httpClient = new HttpClient(mockHandler);
         var repository = new MenuRepository(context);
-        var scrapingService = new MenuScrapingService(httpClient, repository);
+        var scrapingService = new MenuScrapingService(httpClient, repository, new TimeZoneService());
 
         // Act - First call should scrape from website
         var firstResult = await scrapingService.ScrapeMenuAsync();
@@ -261,7 +264,7 @@ public class MenuScrapingServiceTests
     public void ParseNuxtData_ExtractsAllMenuTypes()
     {
         var html = File.ReadAllText(_testHtmlPath);
-        var result = MenuScrapingService.ParseNuxtData(html);
+        var result = MenuScrapingService.ParseNuxtData(html, FixtureToday);
 
         var groups = result.GroupBy(r => r.MenuType).OrderBy(g => g.Key).ToList();
         foreach (var g in groups)
@@ -315,7 +318,7 @@ public class MenuScrapingServiceTests
     [Fact]
     public void ParseWeekDates_ParsesCorrectly()
     {
-        var dates = MenuScrapingService.ParseWeekDates("Uge 11");
+        var dates = MenuScrapingService.ParseWeekDates("Uge 11", FixtureToday);
         Assert.Equal(5, dates.Count);
         Assert.Equal(new DateTime(2026, 3, 9), dates[0]); // Monday
         Assert.Equal(new DateTime(2026, 3, 13), dates[4]); // Friday
@@ -325,7 +328,7 @@ public class MenuScrapingServiceTests
     public void ParseNuxtData_MainDishDoesNotContainDietPrefix()
     {
         var html = File.ReadAllText(_testHtmlPath);
-        var result = MenuScrapingService.ParseNuxtData(html);
+        var result = MenuScrapingService.ParseNuxtData(html, FixtureToday);
 
         foreach (var day in result)
         {
@@ -342,7 +345,7 @@ public class MenuScrapingServiceTests
     public void ParseNuxtData_MainDishHasNoTrailingPeriod()
     {
         var html = File.ReadAllText(_testHtmlPath);
-        var result = MenuScrapingService.ParseNuxtData(html);
+        var result = MenuScrapingService.ParseNuxtData(html, FixtureToday);
 
         foreach (var day in result)
         {
@@ -354,6 +357,9 @@ public class MenuScrapingServiceTests
 
 public class MenuScrapingServiceFoodopTests
 {
+    // Fixed date matching the foodop fixture data (Apr 7-10, 2026)
+    private static readonly DateTime FixtureToday = new(2026, 4, 7);
+
     private readonly string _testHtmlPath;
 
     public MenuScrapingServiceFoodopTests()
@@ -366,7 +372,7 @@ public class MenuScrapingServiceFoodopTests
     public void ParseNuxtData_FoodopFormat_ReturnsMenuDays()
     {
         var html = File.ReadAllText(_testHtmlPath);
-        var result = MenuScrapingService.ParseNuxtData(html);
+        var result = MenuScrapingService.ParseNuxtData(html, FixtureToday);
 
         Assert.NotEmpty(result);
     }
@@ -375,7 +381,7 @@ public class MenuScrapingServiceFoodopTests
     public void ParseNuxtData_FoodopFormat_ExtractsAllMenuTypes()
     {
         var html = File.ReadAllText(_testHtmlPath);
-        var result = MenuScrapingService.ParseNuxtData(html);
+        var result = MenuScrapingService.ParseNuxtData(html, FixtureToday);
 
         var menuTypes = result.Select(r => r.MenuType).Distinct().OrderBy(t => t).ToList();
         Assert.Contains("Almanak", menuTypes);
@@ -390,7 +396,7 @@ public class MenuScrapingServiceFoodopTests
     public void ParseNuxtData_FoodopFormat_HasCorrectDates()
     {
         var html = File.ReadAllText(_testHtmlPath);
-        var result = MenuScrapingService.ParseNuxtData(html);
+        var result = MenuScrapingService.ParseNuxtData(html, FixtureToday);
 
         var dates = result.Select(r => r.Date).Distinct().OrderBy(d => d).ToList();
 
@@ -405,7 +411,7 @@ public class MenuScrapingServiceFoodopTests
     public void ParseNuxtData_FoodopFormat_HasCorrectDayNames()
     {
         var html = File.ReadAllText(_testHtmlPath);
-        var result = MenuScrapingService.ParseNuxtData(html);
+        var result = MenuScrapingService.ParseNuxtData(html, FixtureToday);
 
         var tuesday = result.FirstOrDefault(r => r.Date == new DateTime(2026, 4, 7));
         Assert.NotNull(tuesday);
@@ -420,7 +426,7 @@ public class MenuScrapingServiceFoodopTests
     public void ParseNuxtData_FoodopFormat_MenuItemsHaveCategoryPrefix()
     {
         var html = File.ReadAllText(_testHtmlPath);
-        var result = MenuScrapingService.ParseNuxtData(html);
+        var result = MenuScrapingService.ParseNuxtData(html, FixtureToday);
 
         foreach (var day in result)
         {
@@ -434,7 +440,7 @@ public class MenuScrapingServiceFoodopTests
     public void ParseNuxtData_FoodopFormat_ExtractsMainDish()
     {
         var html = File.ReadAllText(_testHtmlPath);
-        var result = MenuScrapingService.ParseNuxtData(html);
+        var result = MenuScrapingService.ParseNuxtData(html, FixtureToday);
 
         foreach (var day in result)
         {
@@ -447,7 +453,7 @@ public class MenuScrapingServiceFoodopTests
     public void ParseNuxtData_FoodopFormat_MainDishHasNoDietPrefix()
     {
         var html = File.ReadAllText(_testHtmlPath);
-        var result = MenuScrapingService.ParseNuxtData(html);
+        var result = MenuScrapingService.ParseNuxtData(html, FixtureToday);
 
         foreach (var day in result)
         {
@@ -461,7 +467,7 @@ public class MenuScrapingServiceFoodopTests
     public void ParseNuxtData_FoodopFormat_NoDuplicateEntries()
     {
         var html = File.ReadAllText(_testHtmlPath);
-        var result = MenuScrapingService.ParseNuxtData(html);
+        var result = MenuScrapingService.ParseNuxtData(html, FixtureToday);
 
         var keys = result.Select(r => $"{r.Date:yyyy-MM-dd}|{r.MenuType}").ToList();
         Assert.Equal(keys.Count, keys.Distinct().Count());
@@ -471,7 +477,7 @@ public class MenuScrapingServiceFoodopTests
     public void ParseNuxtData_FoodopFormat_AlmanakMondayHasExpectedContent()
     {
         var html = File.ReadAllText(_testHtmlPath);
-        var result = MenuScrapingService.ParseNuxtData(html);
+        var result = MenuScrapingService.ParseNuxtData(html, FixtureToday);
 
         var almanakMonday = result.FirstOrDefault(r =>
             r.MenuType == "Almanak" && r.Date == new DateTime(2026, 4, 7));

--- a/Meyers.Test/TestWebApplicationFactory.cs
+++ b/Meyers.Test/TestWebApplicationFactory.cs
@@ -74,7 +74,8 @@ public class TestWebApplicationFactory : WebApplicationFactory<Program>, IDispos
             services.AddScoped<MenuScrapingService>(provider =>
             {
                 var repository = provider.GetRequiredService<IMenuRepository>();
-                return new MenuScrapingService(mockHttpClient, repository);
+                var timeZoneService = provider.GetRequiredService<ITimeZoneService>();
+                return new MenuScrapingService(mockHttpClient, repository, timeZoneService);
             });
 
             // Build the service provider and ensure the database is created

--- a/Meyers.Web/App.razor
+++ b/Meyers.Web/App.razor
@@ -5,13 +5,17 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <title>Meyers Menu Calendar</title>
     <base href="/"/>
+    <link rel="preconnect" href="https://fonts.googleapis.com"/>
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+    <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,300..900;1,9..144,300..900&family=IBM+Plex+Mono:wght@400;500;600&display=swap"
+          rel="stylesheet"/>
     <link href="@Assets["css/app.css"]" rel="stylesheet"/>
     <link rel="icon"
-          href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🍽️</text></svg>"/>
+          href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><circle cx='50' cy='50' r='48' fill='%23a93b28'/><text x='50' y='70' font-size='58' font-family='Georgia,serif' font-style='italic' fill='%23fdfaf1' text-anchor='middle'>M</text></svg>"/>
     <script src="@Assets["js/menu-app.js"]" defer></script>
     <HeadOutlet/>
 </head>
-<body class="bg-app text-slate-900 dark:text-slate-100 antialiased">
+<body class="bg-app text-ink antialiased">
 <Routes/>
 </body>
 </html>

--- a/Meyers.Web/Components/CopyButton.razor
+++ b/Meyers.Web/Components/CopyButton.razor
@@ -7,7 +7,7 @@
 @code {
     [Parameter] public string? Value { get; set; }
     [Parameter] public string? InputId { get; set; }
-    [Parameter] public string CssClass { get; set; } = "px-5 py-3 font-medium text-white bg-teal-700 hover:bg-teal-600 transition-colors";
+    [Parameter] public string CssClass { get; set; } = "btn-primary";
     [Parameter] public RenderFragment? ChildContent { get; set; }
 
     private string GetOnClickScript()

--- a/Meyers.Web/Components/CustomRadio.razor
+++ b/Meyers.Web/Components/CustomRadio.razor
@@ -35,15 +35,14 @@
 
     private string GetInputClasses()
     {
-        var baseClasses = @"text-teal-600 bg-white dark:bg-slate-700 border-slate-300 dark:border-slate-600 " +
-                          "focus:ring-teal-500 dark:focus:ring-teal-400 focus:ring-2 " +
-                          "transition-all duration-200 appearance-none rounded-full border-2 " +
-                          "checked:bg-teal-600 checked:border-teal-600 dark:checked:bg-teal-500 dark:checked:border-teal-500 " +
-                          "hover:border-slate-400 dark:hover:border-slate-500 " +
+        var baseClasses = @"peer bg-transparent border-ink-faint " +
+                          "transition-all duration-200 appearance-none rounded-full border " +
+                          "checked:bg-madder checked:border-madder " +
+                          "hover:border-ink focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-madder " +
                           "relative cursor-pointer " +
-                          "before:content-[''] before:absolute before:inset-0 before:rounded-full " +
-                          "before:bg-white dark:before:bg-slate-700 before:scale-0 before:transition-transform " +
-                          "checked:before:scale-50 checked:before:bg-white";
+                          "before:content-[''] before:absolute before:inset-[3px] before:rounded-full " +
+                          "before:bg-cream before:scale-0 before:transition-transform " +
+                          "checked:before:scale-100";
 
         var sizeClasses = Size switch
         {
@@ -64,7 +63,7 @@
             _ => "text-base"
         };
 
-        return $"font-medium text-slate-900 dark:text-slate-100 {sizeClasses}".Trim();
+        return $"font-display text-ink-soft peer-checked:text-ink peer-checked:font-medium transition-colors {sizeClasses}".Trim();
     }
 
 }

--- a/Meyers.Web/Components/CustomSelect.razor
+++ b/Meyers.Web/Components/CustomSelect.razor
@@ -34,18 +34,17 @@
 
     private string GetCssClasses()
     {
-        var baseClasses = @"border border-slate-300/60 dark:border-slate-600/60 rounded-lg " +
-                          "bg-white/80 dark:bg-slate-800/60 text-slate-900 dark:text-slate-100 " +
-                          "focus:ring-2 focus:ring-teal-500 focus:border-teal-500 dark:focus:ring-teal-400 " +
-                          "appearance-none cursor-pointer transition-all duration-200 " +
-                          "hover:border-slate-400 dark:hover:border-slate-500 " +
+        var baseClasses = @"appearance-none cursor-pointer bg-transparent font-display text-ink " +
+                          "border-0 border-b border-ink-faint rounded-none " +
+                          "hover:border-ink focus:border-madder focus:outline-none " +
+                          "transition-colors duration-200 " +
                           "custom-select-arrow bg-no-repeat";
 
         var sizeClasses = Size switch
         {
-            SelectSize.Small => "px-3 py-2 pr-8 custom-select-small",
-            SelectSize.Large => "px-4 py-3 pr-10 custom-select-large",
-            _ => "px-3 py-2 pr-8 custom-select-medium"
+            SelectSize.Small => "px-1 py-1.5 pr-7 text-sm custom-select-small",
+            SelectSize.Large => "px-2 py-2.5 pr-9 text-xl custom-select-large",
+            _ => "px-1 py-2 pr-8 text-base custom-select-medium"
         };
 
         var alignmentClasses = Centered ? "text-center" : "";

--- a/Meyers.Web/Components/Home.razor
+++ b/Meyers.Web/Components/Home.razor
@@ -9,44 +9,34 @@
 
 <PageTitle>Meyers Menu Calendar</PageTitle>
 
-<div class="max-w-5xl mx-auto">
-    <!-- Hero -->
-    <section class="text-center mb-12">
-        <span class="kicker">Calendar feed for lunch menus</span>
-        <h2 class="mt-2 text-4xl font-extrabold tracking-tight
-               text-slate-900 dark:text-white">
-            Never miss lunch again
-        </h2>
-        <p class="mt-3 text-lg text-slate-600 dark:text-slate-300 max-w-2xl mx-auto">
-            Get Meyers daily menus delivered straight to your calendar. Simple,
-            automatic, and always up to date.
+<div class="max-w-2xl mx-auto">
+    <!-- Intro -->
+    <section class="text-center mb-12 reveal">
+        <p class="font-display text-xl leading-relaxed text-ink-soft max-w-xl mx-auto">
+            Choose a menu for each weekday, subscribe once, and the day&rsquo;s dish appears
+            in your calendar <em class="text-madder">before you&rsquo;re hungry</em>.
         </p>
-
     </section>
 
-    <!-- Menu Selection Interface -->
-    <section class="mb-12">
-        <div class="card p-4 sm:p-8 max-w-4xl mx-auto">
-            <!-- Radio Button Selection -->
-            <div class="mb-6">
-                <div class="flex flex-col sm:flex-row items-center justify-center gap-4 sm:gap-8">
-                    <CustomRadio name="menuMode" value="simple" Size="CustomRadio.RadioSize.Medium"
-                                 checked onchange="toggleMenuMode()">
-                        Simple - One menu for all days
-                    </CustomRadio>
-                    <CustomRadio name="menuMode" value="custom" Size="CustomRadio.RadioSize.Medium"
-                                 onchange="toggleMenuMode()">
-                        Custom - Different menus per day
-                    </CustomRadio>
-                </div>
+    <!-- Compose -->
+    <section class="mb-10 reveal" style="animation-delay: 90ms">
+        <div class="card menu-frame px-6 py-8 sm:px-10 sm:py-9">
+            <h2 class="section-title mb-7">Compose your calendar</h2>
+
+            <div class="flex flex-col sm:flex-row items-center justify-center gap-3 sm:gap-10 mb-7">
+                <CustomRadio name="menuMode" value="simple" Size="CustomRadio.RadioSize.Medium"
+                             checked onchange="toggleMenuMode()">
+                    One menu, every day
+                </CustomRadio>
+                <CustomRadio name="menuMode" value="custom" Size="CustomRadio.RadioSize.Medium"
+                             onchange="toggleMenuMode()">
+                    Mix menus per weekday
+                </CustomRadio>
             </div>
 
             <!-- Simple Mode: Single Dropdown -->
             <div id="simpleMode">
-                <div class="max-w-md mx-auto">
-                    <label class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-3 text-center">
-                        Select menu for all weekdays
-                    </label>
+                <div class="max-w-sm mx-auto">
                     <CustomSelect id="simpleMenuSelect"
                                   Class="w-full"
                                   Size="CustomSelect.SelectSize.Large"
@@ -64,116 +54,112 @@
 
             <!-- Custom Mode: Five Dropdowns -->
             <div id="customMode" class="hidden">
-                <div class="max-w-2xl mx-auto">
-                    <div class="space-y-4">
-                        @foreach (var day in new[]
-                                      {
-                                          (DayOfWeek.Monday, "Monday"),
-                                          (DayOfWeek.Tuesday, "Tuesday"),
-                                          (DayOfWeek.Wednesday, "Wednesday"),
-                                          (DayOfWeek.Thursday, "Thursday"),
-                                          (DayOfWeek.Friday, "Friday")
-                                      })
-                        {
-                            <div
-                                class="flex flex-col sm:flex-row sm:items-center sm:justify-between p-4 rounded-lg border border-slate-200 dark:border-slate-700 bg-slate-50/50 dark:bg-slate-800/50 gap-3">
-                                <span class="font-medium text-slate-900 dark:text-slate-100 text-sm sm:text-base">
-                                    @day.Item2
-                                </span>
-                                <CustomSelect Class="custom-day-select w-full sm:max-w-xs"
-                                              Size="CustomSelect.SelectSize.Medium"
-                                              data-day="@((int)day.Item1)"
-                                              onchange="updateCalendarUrl()">
-                                    @foreach (var menuType in menuTypes)
-                                    {
-                                        var isSelected = (day.Item1 == DayOfWeek.Monday && menuType.Slug == "det-velkendte") ||
-                                                             (day.Item1 == DayOfWeek.Tuesday && menuType.Slug == "det-velkendte") ||
-                                                             (day.Item1 == DayOfWeek.Wednesday && menuType.Slug == "det-velkendte") ||
-                                                             (day.Item1 == DayOfWeek.Thursday && menuType.Slug == "den-groenne") ||
-                                                             (day.Item1 == DayOfWeek.Friday && menuType.Slug == "det-velkendte");
-                                        <option value="@menuType.Id" data-slug="@menuType.Slug"
-                                                selected="@isSelected">@menuType.Name</option>
-                                    }
-                                </CustomSelect>
-                            </div>
-                        }
-                    </div>
+                <div class="max-w-md mx-auto divide-y divide-rule/60">
+                    @foreach (var day in new[]
+                                  {
+                                      (DayOfWeek.Monday, "Monday"),
+                                      (DayOfWeek.Tuesday, "Tuesday"),
+                                      (DayOfWeek.Wednesday, "Wednesday"),
+                                      (DayOfWeek.Thursday, "Thursday"),
+                                      (DayOfWeek.Friday, "Friday")
+                                  })
+                    {
+                        <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-1.5 sm:gap-4 py-3">
+                            <span class="font-mono text-[11px] uppercase tracking-[0.16em] text-ink-soft">
+                                @day.Item2
+                            </span>
+                            <CustomSelect Class="custom-day-select w-full sm:w-64"
+                                          Size="CustomSelect.SelectSize.Medium"
+                                          data-day="@((int)day.Item1)"
+                                          onchange="updateCalendarUrl()">
+                                @foreach (var menuType in menuTypes)
+                                {
+                                    var isSelected = (day.Item1 == DayOfWeek.Monday && menuType.Slug == "det-velkendte") ||
+                                                         (day.Item1 == DayOfWeek.Tuesday && menuType.Slug == "det-velkendte") ||
+                                                         (day.Item1 == DayOfWeek.Wednesday && menuType.Slug == "det-velkendte") ||
+                                                         (day.Item1 == DayOfWeek.Thursday && menuType.Slug == "den-groenne") ||
+                                                         (day.Item1 == DayOfWeek.Friday && menuType.Slug == "det-velkendte");
+                                    <option value="@menuType.Id" data-slug="@menuType.Slug"
+                                            selected="@isSelected">@menuType.Name</option>
+                                }
+                            </CustomSelect>
+                        </div>
+                    }
                 </div>
             </div>
         </div>
     </section>
 
-    <!-- Weekly Calendar Preview -->
-    <section class="mb-12">
-        <div class="card p-4 sm:p-8 max-w-6xl mx-auto">
-            <h3 class="text-2xl font-semibold text-slate-900 dark:text-slate-100 mb-6 text-center flex items-center justify-center">
-                <span class="text-2xl mr-3">📅</span>
-                Next 7 Days Preview
-            </h3>
-
-            <div id="weeklyPreview" class="grid grid-cols-1 md:grid-cols-7 gap-2 mb-8">
-                <!-- This will be populated by JavaScript -->
+    <!-- Week ahead -->
+    <section class="mb-12 reveal" style="animation-delay: 180ms">
+        <div class="card menu-frame px-6 py-8 sm:px-10 sm:py-9">
+            <h2 class="section-title mb-4">The week ahead</h2>
+            <div id="weeklyPreview">
+                <!-- Populated by JavaScript -->
             </div>
+        </div>
+    </section>
 
-            <!-- Calendar URL and Instructions -->
-            <div class="border-t border-slate-200 dark:border-slate-700 pt-8">
-                <div class="max-w-2xl mx-auto">
-                    <div class="mb-6">
-                        <label class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-3 text-center">
-                            Your Calendar Feed URL
-                        </label>
-                        <div class="flex rounded-lg border border-slate-300/60 dark:border-slate-600/60 overflow-hidden
-                            bg-white/80 dark:bg-slate-800/60 backdrop-blur">
-                            <input type="text" id="calendarUrl" value="" readonly class="copy-input"/>
-                            <CopyButton InputId="calendarUrl" CssClass="btn-primary">
-                                Copy Calendar Feed URL
-                            </CopyButton>
-                        </div>
-                    </div>
-
-                    <div class="mb-6 flex justify-center">
-                        <label class="flex items-center cursor-pointer">
-                            <input type="checkbox" id="alarmCheckbox" class="mr-3 w-4 h-4 text-teal-600 
-                                   bg-gray-100 border-gray-300 focus:ring-teal-500 dark:focus:ring-teal-600 
-                                   dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600"
-                                   onchange="updateCalendarUrl()">
-                            <span class="text-sm font-medium text-slate-700 dark:text-slate-300">
-                                🔔 Add 5-minute alarm before lunch
-                            </span>
-                        </label>
-                    </div>
-
-                    <div class="p-6 rounded-xl border border-teal-200/60 dark:border-teal-700/50
-                          bg-teal-50/70 dark:bg-teal-900/20">
-                        <h4 class="font-semibold text-slate-900 dark:text-slate-100 mb-3 text-center">
-                            How to add to your calendar
-                        </h4>
-                        <div class="grid md:grid-cols-3 gap-4 text-sm text-slate-700 dark:text-slate-300">
-                            <div class="text-center">
-                                <span class="font-medium block mb-1">Google Calendar</span>
-                                <span>Settings → Add calendar → From URL</span>
-                            </div>
-                            <div class="text-center">
-                                <span class="font-medium block mb-1">Outlook</span>
-                                <span>Add calendar → Subscribe from web</span>
-                            </div>
-                            <div class="text-center">
-                                <span class="font-medium block mb-1">Apple Calendar</span>
-                                <span>File → New Calendar Subscription</span>
-                            </div>
-                        </div>
-                        <div class="mt-4 text-center">
-                            <span class="pill">Works with Google, Outlook, Apple Calendar</span>
-                        </div>
-                    </div>
-                </div>
+    <!-- Feed URL ticket -->
+    <section class="mb-12 reveal" style="animation-delay: 270ms">
+        <div class="ticket">
+            <span class="ticket-label">&#9988; Your calendar feed</span>
+            <div class="flex items-stretch p-1.5 gap-1.5">
+                <input type="text" id="calendarUrl" value="" readonly class="copy-input"/>
+                <CopyButton InputId="calendarUrl" CssClass="btn-primary shrink-0">
+                    Copy
+                </CopyButton>
             </div>
+        </div>
+
+        <div class="mt-5 flex justify-center">
+            <label class="flex items-center gap-2.5 cursor-pointer">
+                <input type="checkbox" id="alarmCheckbox" class="size-4 accent-madder"
+                       onchange="updateCalendarUrl()">
+                <span class="text-[15px] text-ink-soft">
+                    Ring a bell five minutes before lunch
+                </span>
+            </label>
+        </div>
+    </section>
+
+    <!-- How to subscribe -->
+    <section class="mb-10 reveal" style="animation-delay: 360ms">
+        <h2 class="section-title mb-7">How to subscribe</h2>
+        <div class="grid sm:grid-cols-3 gap-6 sm:gap-0 sm:divide-x divide-rule/70 text-center">
+            <div class="px-4">
+                <span class="block font-mono text-[10px] uppercase tracking-[0.16em] text-ink mb-1.5">
+                    Google Calendar
+                </span>
+                <span class="text-sm leading-relaxed text-ink-soft">
+                    Settings &rarr; Add calendar &rarr; From URL
+                </span>
+            </div>
+            <div class="px-4">
+                <span class="block font-mono text-[10px] uppercase tracking-[0.16em] text-ink mb-1.5">
+                    Outlook
+                </span>
+                <span class="text-sm leading-relaxed text-ink-soft">
+                    Add calendar &rarr; Subscribe from web
+                </span>
+            </div>
+            <div class="px-4">
+                <span class="block font-mono text-[10px] uppercase tracking-[0.16em] text-ink mb-1.5">
+                    Apple Calendar
+                </span>
+                <span class="text-sm leading-relaxed text-ink-soft">
+                    File &rarr; New Calendar Subscription
+                </span>
+            </div>
+        </div>
+        <div class="mt-7 text-center">
+            <span class="pill">Updates itself &middot; No app required</span>
         </div>
     </section>
 
     <!-- Last updated timestamp -->
     <div class="mt-12 text-center">
-        <p class="text-xs text-slate-500 dark:text-slate-400">
+        <p class="font-mono text-[10px] uppercase tracking-[0.14em] text-ink-faint">
             @FormatLastUpdated()
         </p>
     </div>

--- a/Meyers.Web/Components/MainLayout.razor
+++ b/Meyers.Web/Components/MainLayout.razor
@@ -18,62 +18,56 @@
   <meta name="twitter:description" content="Fresh lunch menus delivered to your calendar">
 </HeadContent>
 
-<div class="min-h-screen bg-app">
-  <header class="bg-white/70 dark:bg-slate-900/70 backdrop-blur-lg
-                 border-b border-slate-200/60 dark:border-slate-700/60
-                 sticky top-0 z-10">
-    <div class="container mx-auto px-4 py-5">
-      <div class="flex items-center justify-between">
-        <a href="/" class="flex items-center gap-4 hover:opacity-80 transition-opacity">
-          <div class="flex h-10 w-10 items-center justify-center rounded-xl
-                      bg-gradient-to-br from-teal-400 to-teal-600 text-white shadow-sm">
-            <span class="text-lg">🍽️</span>
-          </div>
-          <div>
-            <h1 class="text-xl md:text-2xl font-bold tracking-tight
-                       text-slate-900 dark:text-white">
-              Meyers Menu Calendar
-            </h1>
-            <div class="flex items-center gap-2 mt-1">
-              <p class="text-slate-600 dark:text-slate-300 text-sm">
-                Fresh lunch menus delivered to your calendar
-              </p>
-            </div>
-          </div>
+<div class="min-h-screen bg-app flex flex-col">
+  <div class="h-1 bg-madder"></div>
+
+  <header class="pt-10 pb-2">
+    <div class="container mx-auto px-4 max-w-3xl relative">
+      <div class="absolute right-4 top-0 hidden sm:flex items-center gap-1">
+        <a href="/admin" class="btn-ghost" title="Admin Dashboard">Admin</a>
+        <a href="https://github.com/larssg/meyers-menu-calendar" target="_blank" class="btn-ghost"
+           title="Built by Lars Sehested" aria-label="GitHub">
+          <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 20 20"
+               aria-hidden="true">
+            <path fill-rule="evenodd"
+                  d="M10 0C4.477 0 0 4.484 0 10.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0110 4.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.203 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.942.359.31.678.921.678 1.856 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0020 10.017C20 4.484 15.522 0 10 0z"
+                  clip-rule="evenodd"></path>
+          </svg>
         </a>
-        <div class="hidden sm:flex items-center gap-2">
-          <a href="/admin" class="btn-ghost text-xs" title="Admin Dashboard">⚙️</a>
-          <a href="https://github.com/larssg/meyers-menu-calendar" target="_blank" class="btn-ghost"
-             title="Built by Lars Sehested" aria-label="GitHub">
-            <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20"
-                 aria-hidden="true">
-              <path fill-rule="evenodd"
-                    d="M10 0C4.477 0 0 4.484 0 10.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0110 4.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.203 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.942.359.31.678.921.678 1.856 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0020 10.017C20 4.484 15.522 0 10 0z"
-                    clip-rule="evenodd"></path>
-            </svg>
-          </a>
-        </div>
       </div>
+
+      <a href="/" class="block text-center group">
+        <p class="kicker">Man &ndash; Fre &middot; Frokost &middot; K&oslash;benhavn</p>
+        <h1 class="mt-3 font-display text-4xl md:text-5xl font-semibold tracking-tight text-ink
+                   group-hover:text-madder-deep transition-colors">
+          Meyers Menu Calendar
+        </h1>
+        <p class="mt-2 font-display italic text-ink-soft">
+          Fresh lunch menus, delivered to your calendar
+        </p>
+      </a>
+      <div class="scotch-rule mt-8"></div>
     </div>
   </header>
 
-  <main class="container mx-auto px-4 py-12">
+  <main class="container mx-auto px-4 py-10 flex-1 w-full">
     @Body
   </main>
 
-  <footer class="bg-white/60 dark:bg-slate-900/60 backdrop-blur-md
-                 border-t border-slate-200/60 dark:border-slate-700/60 mt-auto">
-    <div class="container mx-auto px-4 py-8">
-      <div class="flex flex-col items-center justify-center space-y-4">
-        <div class="text-center text-sm text-slate-600 dark:text-slate-400">
-          <p>Built by Lars Sehested • Not affiliated with Meyers Kantiner</p>
-          <p class="text-xs mt-1">Open-source friendly • Feedback welcome</p>
-        </div>
+  <footer class="mt-12 pb-12">
+    <div class="container mx-auto px-4 max-w-3xl">
+      <div class="border-t border-rule pt-8 text-center space-y-3">
+        <p class="font-display italic text-ink-soft">Velbekomme.</p>
+        <p class="font-mono text-[10px] uppercase tracking-[0.2em] text-ink-faint">
+          Built by Lars Sehested &middot; Not affiliated with Meyers Kantiner
+        </p>
+        <p class="font-mono text-[10px] uppercase tracking-[0.2em] text-ink-faint">
+          Open-source friendly &middot; Feedback welcome
+        </p>
         <a href="https://github.com/larssg/meyers-menu-calendar" target="_blank"
-           class="text-slate-400 dark:text-slate-500 hover:text-slate-600
-                  dark:hover:text-slate-300 transition-colors group"
+           class="inline-block text-ink-faint hover:text-ink transition-colors"
            title="View my GitHub" aria-label="GitHub">
-          <svg class="w-6 h-6" fill="currentColor" viewBox="0 0 20 20"
+          <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20"
                aria-hidden="true">
             <path fill-rule="evenodd"
                   d="M10 0C4.477 0 0 4.484 0 10.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0110 4.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.203 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.942.359.31.678.921.678 1.856 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0020 10.017C20 4.484 15.522 0 10 0z"

--- a/Meyers.Web/Handlers/CalendarEndpointHandler.cs
+++ b/Meyers.Web/Handlers/CalendarEndpointHandler.cs
@@ -12,6 +12,7 @@ public partial class CalendarEndpointHandler(
     IMenuScrapingService menuScrapingService,
     ICalendarService calendarService,
     IMenuRepository menuRepository,
+    ITimeZoneService timeZoneService,
     IOptions<MenuCacheOptions> cacheOptions)
 {
     public async Task<IResult> GetCalendarAsync(string menuTypeSlug, HttpContext httpContext)
@@ -22,8 +23,9 @@ public partial class CalendarEndpointHandler(
             var currentMenuDays = await menuScrapingService.ScrapeMenuAsync();
 
             // Also get historical data from the last month plus any future items
-            var startDate = DateTime.Today.AddMonths(-1);
-            var endDate = DateTime.Today.AddMonths(1); // Get up to one month in the future
+            var today = timeZoneService.GetCopenhagenDate();
+            var startDate = today.AddMonths(-1);
+            var endDate = today.AddMonths(1); // Get up to one month in the future
 
             // Get specific menu type
             var menuType = await menuRepository.GetMenuTypeBySlugAsync(menuTypeSlug);
@@ -88,8 +90,9 @@ public partial class CalendarEndpointHandler(
             var currentMenuDays = await menuScrapingService.ScrapeMenuAsync();
 
             // Get historical data from the last month plus any future items
-            var startDate = DateTime.Today.AddMonths(-1);
-            var endDate = DateTime.Today.AddMonths(1);
+            var today = timeZoneService.GetCopenhagenDate();
+            var startDate = today.AddMonths(-1);
+            var endDate = today.AddMonths(1);
 
             // Get all menu types we need
             var allMenuTypes = await menuRepository.GetMenuTypesAsync();

--- a/Meyers.Web/Styles/app.css
+++ b/Meyers.Web/Styles/app.css
@@ -1,140 +1,368 @@
 @import "tailwindcss";
 
+/* Light-only theme: dark: variants require a .dark class that is never set */
+@custom-variant dark (&:where(.dark, .dark *));
+
 /* Tailwind v4 CSS-based configuration */
 @theme {
-    /* Neutral palette */
-    --color-ink-950: #0b1220;
-    --color-ink-900: #0f172a;
+    --font-display: "Fraunces", Georgia, "Times New Roman", serif;
+    --font-mono: "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
 
-    --color-stone-900: #1f2937;
-    --color-stone-800: #334155;
-    --color-stone-700: #475569;
-    --color-stone-600: #64748b;
-    --color-stone-500: #94a3b8;
-    --color-stone-400: #cbd5e1;
-    --color-stone-300: #e2e8f0;
-    --color-stone-200: #e9eef6;
-    --color-stone-100: #f3f6fb;
-    --color-stone-50: #f7f9fd;
+    /* Paper & ink */
+    --color-paper: #f5f0e4;
+    --color-parchment: #ece4cf;
+    --color-cream: #fdfaf1;
+    --color-ink: #26211a;
+    --color-ink-soft: #645b4b;
+    --color-ink-faint: #9b9180;
+    --color-rule: #d8cdb4;
 
     /* Accents */
-    --color-sea-900: #0f766e;
-    --color-sea-800: #0d9488;
-    --color-sea-700: #14b8a6;
-    --color-sea-100: #e6fffb;
+    --color-madder: #a93b28;
+    --color-madder-deep: #8a2e1e;
+    --color-madder-wash: #f3e0d6;
+    --color-olive: #5d6c3c;
+    --color-olive-wash: #e9ecd8;
 
-    --color-coral-800: #c2410c;
-    --color-coral-600: #f97316;
-    --color-coral-100: #fff1e6;
+    --shadow-card: 0 1px 2px rgb(64 51 26 / 0.05), 0 14px 36px -20px rgb(64 51 26 / 0.28);
+}
 
-    --shadow-soft: 0 16px 30px -20px rgba(15, 23, 42, 0.25);
-    --shadow-subtle: 0 10px 24px -18px rgba(15, 23, 42, 0.18);
+@layer base {
+    :root {
+        color-scheme: light;
+    }
+
+    body {
+        font-family: var(--font-display);
+        font-optical-sizing: auto;
+        background-color: var(--color-paper);
+        color: var(--color-ink);
+    }
+
+    /* Paper grain */
+    body::before {
+        content: "";
+        position: fixed;
+        inset: 0;
+        z-index: 40;
+        pointer-events: none;
+        opacity: 0.05;
+        background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='180' height='180'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='2'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+    }
+
+    ::selection {
+        background: var(--color-madder-wash);
+        color: var(--color-ink);
+    }
 }
 
 /* Component utilities */
 @layer utilities {
     .bg-app {
-        @apply bg-gradient-to-br from-slate-50 via-white to-slate-100
-        dark:from-slate-900 dark:via-slate-950 dark:to-slate-900;
+        background-color: var(--color-paper);
+        background-image: radial-gradient(120% 60% at 50% 0%, rgb(255 253 244 / 0.8), transparent 70%);
     }
 
     .card {
-        @apply rounded-2xl border border-slate-200/60 dark:border-slate-700/50
-        bg-white/80 dark:bg-slate-900/70 backdrop-blur-md shadow;
-        box-shadow: var(--shadow-soft);
+        position: relative;
+        border-radius: 0.25rem;
+        border: 1px solid var(--color-rule);
+        background-color: var(--color-cream);
+        box-shadow: var(--shadow-card);
+    }
+
+    /* Inset hairline, like a printed menu-card frame */
+    .menu-frame::before {
+        content: "";
+        position: absolute;
+        inset: 7px;
+        border: 1px solid color-mix(in srgb, var(--color-rule) 70%, transparent);
+        pointer-events: none;
     }
 
     .panel {
-        @apply rounded-xl border border-slate-200/60 dark:border-slate-700/50
-        bg-white/70 dark:bg-slate-800/60 backdrop-blur-md shadow;
-        box-shadow: var(--shadow-subtle);
+        border-radius: 0.25rem;
+        border: 1px solid var(--color-rule);
+        background-color: var(--color-paper);
     }
 
     .btn-primary {
-        @apply inline-flex items-center justify-center rounded-lg px-5 py-3
-        font-medium text-white bg-teal-700 hover:bg-teal-600 active:bg-teal-800
-        transition-colors shadow-sm;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        font-family: var(--font-mono);
+        font-size: 0.72rem;
+        font-weight: 600;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        color: var(--color-cream);
+        background-color: var(--color-madder);
+        padding: 0.75rem 1.25rem;
+        border-radius: 2px;
+        transition: background-color 150ms ease;
+    }
+
+    .btn-primary:hover {
+        background-color: var(--color-madder-deep);
     }
 
     .btn-ghost {
-        @apply inline-flex items-center justify-center rounded-lg px-4 py-2
-        font-medium text-slate-700 dark:text-slate-300
-        hover:bg-slate-100/70 dark:hover:bg-slate-700/50 transition-colors;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        font-family: var(--font-mono);
+        font-size: 0.72rem;
+        letter-spacing: 0.1em;
+        text-transform: uppercase;
+        color: var(--color-ink-soft);
+        padding: 0.45rem 0.7rem;
+        border-radius: 2px;
+        transition: color 150ms ease, background-color 150ms ease;
+    }
+
+    .btn-ghost:hover {
+        color: var(--color-ink);
+        background-color: var(--color-parchment);
     }
 
     .copy-input {
-        @apply flex-1 px-4 py-3 bg-transparent text-sm text-slate-800
-        dark:text-slate-100 focus:outline-none;
+        flex: 1;
+        min-width: 0;
+        padding: 0.85rem 1rem;
+        background: transparent;
+        font-family: var(--font-mono);
+        font-size: 0.78rem;
+        color: var(--color-ink);
+    }
+
+    .copy-input:focus {
+        outline: none;
     }
 
     .kicker {
-        @apply uppercase tracking-widest text-[11px] font-semibold
-        text-slate-500 dark:text-slate-400;
-    }
-
-    .badge-personal {
-        @apply inline-flex items-center px-2 py-0.5 rounded-md text-[10px]
-        font-semibold ring-1 ring-amber-300/60 bg-amber-100 text-amber-800
-        dark:bg-amber-900/40 dark:text-amber-200 dark:ring-amber-800/40;
+        font-family: var(--font-mono);
+        font-size: 0.68rem;
+        font-weight: 500;
+        letter-spacing: 0.28em;
+        text-transform: uppercase;
+        color: var(--color-ink-faint);
     }
 
     .pill {
-        @apply inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs
-        ring-1 ring-teal-300/60 bg-teal-50 text-teal-900
-        dark:bg-teal-900/30 dark:text-teal-200 dark:ring-teal-800/40;
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
+        font-family: var(--font-mono);
+        font-size: 0.62rem;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        color: var(--color-ink-soft);
+        background-color: var(--color-cream);
+        border: 1px solid var(--color-rule);
+        border-radius: 999px;
+        padding: 0.3rem 0.8rem;
     }
 }
 
-/* Smooth theme transitions */
-* {
-    transition: color 150ms ease, background-color 150ms ease,
-    border-color 150ms ease, box-shadow 150ms ease;
+/* Print-style rules */
+.scotch-rule {
+    height: 4px;
+    border-top: 2px solid var(--color-ink);
+    border-bottom: 1px solid var(--color-ink);
 }
 
-/* Optional selection color */
-::selection {
-    background: rgba(13, 148, 136, 0.25); /* teal-600 at 25% */
+.section-title {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    font-family: var(--font-mono);
+    font-size: 0.68rem;
+    font-weight: 500;
+    letter-spacing: 0.22em;
+    text-transform: uppercase;
+    color: var(--color-ink-soft);
+    white-space: nowrap;
 }
 
-/* Line clamp utility for menu preview text */
-.line-clamp-3 {
-    display: -webkit-box;
-    -webkit-line-clamp: 3;
-    -webkit-box-orient: vertical;
-    overflow: hidden;
+.section-title::before,
+.section-title::after {
+    content: "";
+    height: 1px;
+    flex: 1;
+    background: var(--color-rule);
 }
 
-/* Custom select dropdown arrow - cross-browser compatible */
+/* Week-ahead menu rows with dot leaders */
+.menu-row {
+    display: flex;
+    align-items: baseline;
+    gap: 1rem;
+    padding: 0.8rem 0.15rem;
+    border-bottom: 1px solid color-mix(in srgb, var(--color-rule) 60%, transparent);
+}
+
+.menu-row:last-child {
+    border-bottom: 0;
+}
+
+.menu-row-date {
+    flex-shrink: 0;
+    width: 6rem;
+    font-family: var(--font-mono);
+    font-size: 0.66rem;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--color-ink-faint);
+}
+
+.menu-row-today .menu-row-date {
+    color: var(--color-madder);
+    font-weight: 600;
+}
+
+.menu-row-line {
+    display: flex;
+    align-items: baseline;
+    gap: 0.75rem;
+    flex: 1;
+    min-width: 0;
+}
+
+.menu-dish {
+    font-size: 1rem;
+    line-height: 1.45;
+    color: var(--color-ink);
+}
+
+.menu-row-today .menu-dish {
+    font-weight: 600;
+}
+
+.menu-dish-muted {
+    font-style: italic;
+    color: var(--color-ink-faint);
+    font-weight: 400 !important;
+}
+
+.menu-leader {
+    flex: 1;
+    min-width: 1.5rem;
+    align-self: flex-end;
+    margin-bottom: 0.32em;
+    border-bottom: 1px dotted var(--color-ink-faint);
+}
+
+.menu-type {
+    flex-shrink: 0;
+    font-family: var(--font-mono);
+    font-size: 0.62rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--color-ink-soft);
+}
+
+.menu-row-today .menu-type {
+    color: var(--color-madder);
+}
+
+.tag-today {
+    display: inline-block;
+    font-family: var(--font-mono);
+    font-size: 0.58rem;
+    font-weight: 600;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--color-cream);
+    background: var(--color-madder);
+    border-radius: 2px;
+    padding: 0.12rem 0.4rem;
+}
+
+@media (max-width: 520px) {
+    .menu-row {
+        flex-direction: column;
+        gap: 0.25rem;
+    }
+
+    .menu-row-line {
+        flex-wrap: wrap;
+        gap: 0.15rem 0.6rem;
+    }
+
+    .menu-leader {
+        display: none;
+    }
+}
+
+/* Clip-out ticket for the feed URL */
+.ticket {
+    position: relative;
+    border: 1.5px dashed var(--color-ink-faint);
+    border-radius: 4px;
+    background: var(--color-cream);
+}
+
+.ticket-label {
+    position: absolute;
+    top: -0.75em;
+    left: 1rem;
+    padding: 0 0.5rem;
+    background: var(--color-cream);
+    font-family: var(--font-mono);
+    font-size: 0.62rem;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: var(--color-ink-soft);
+}
+
+/* Staggered page-load reveal */
+@keyframes rise {
+    from {
+        opacity: 0;
+        transform: translateY(14px);
+    }
+    to {
+        opacity: 1;
+        transform: none;
+    }
+}
+
+.reveal {
+    animation: rise 0.7s cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .reveal {
+        animation: none;
+    }
+}
+
+/* Custom select dropdown arrow */
 .custom-select-arrow {
-    background-image: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGZpbGw9Im5vbmUiIHZpZXdCb3g9IjAgMCAyNCAyNCIgc3Ryb2tlPSIjNDc1NTY5Ij48cGF0aCBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIHN0cm9rZS13aWR0aD0iMiIgZD0iTTE5IDlsLTcgNy03LTciLz48L3N2Zz4=");
-}
-
-@media (prefers-color-scheme: dark) {
-    .custom-select-arrow {
-        background-image: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGZpbGw9Im5vbmUiIHZpZXdCb3g9IjAgMCAyNCAyNCIgc3Ryb2tlPSIjY2JkNWUxIj48cGF0aCBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIHN0cm9rZS13aWR0aD0iMiIgZD0iTTE5IDlsLTcgNy03LTciLz48L3N2Zz4=");
-    }
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke='%2326211a'%3E%3Cpath stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M19 9l-7 7-7-7'/%3E%3C/svg%3E");
 }
 
 .custom-select-small {
-    background-size: 14px;
-    background-position: right 8px center;
+    background-size: 12px;
+    background-position: right 6px center;
 }
 
 .custom-select-medium {
-    background-size: 14px;
+    background-size: 13px;
     background-position: right 8px center;
 }
 
 .custom-select-large {
-    background-size: 16px;
-    background-position: right 12px center;
+    background-size: 15px;
+    background-position: right 10px center;
 }
 
 /* Blazor error UI */
 #blazor-error-ui {
-    background: lightyellow;
+    background: var(--color-madder-wash);
+    border-top: 1px solid var(--color-madder);
+    color: var(--color-ink);
     bottom: 0;
-    box-shadow: 0 -1px 2px rgba(0, 0, 0, 0.2);
     display: none;
     left: 0;
     padding: 0.6rem 1.25rem 0.7rem 1.25rem;

--- a/Meyers.Web/wwwroot/js/menu-app.js
+++ b/Meyers.Web/wwwroot/js/menu-app.js
@@ -117,8 +117,8 @@ function copyToClipboard(text) {
         const toast = document.createElement('div');
         toast.id = 'copy-toast';
         toast.textContent = 'Copied to clipboard';
-        toast.className = 'fixed bottom-6 left-1/2 -translate-x-1/2 z-50 px-4 py-2 ' +
-            'rounded-lg bg-teal-700 text-white text-sm shadow';
+        toast.className = 'fixed bottom-6 left-1/2 -translate-x-1/2 z-50 px-4 py-2.5 ' +
+            'rounded-sm bg-ink text-cream font-mono text-[11px] uppercase tracking-[0.18em] shadow-lg';
         document.body.appendChild(toast);
         setTimeout(() => toast.remove(), TOAST_DURATION);
     });
@@ -365,31 +365,30 @@ function updateWeeklyPreview() {
             }
         }
 
-        const dayElement = document.createElement('div');
-        dayElement.className = `p-3 rounded-lg border ${
-            isWeekend
-                ? 'bg-gray-100 dark:bg-gray-800 border-gray-200 dark:border-gray-700'
-                : 'bg-white dark:bg-slate-800 border-slate-200 dark:border-slate-700'
-        } ${index === 0 ? 'ring-2 ring-teal-500' : ''}`;
+        const row = document.createElement('div');
+        row.className = 'menu-row' + (index === 0 ? ' menu-row-today' : '');
 
-        dayElement.innerHTML = `
-            <div class="text-center mb-2">
-                <div class="text-xs font-medium text-slate-600 dark:text-slate-400">${dayInfo.dayName}</div>
-                <div class="text-lg font-semibold text-slate-900 dark:text-slate-100">${dayInfo.dayNumber}</div>
-                <div class="text-xs text-slate-500 dark:text-slate-500">${dayInfo.monthName}</div>
-            </div>
-            ${isWeekend ?
-            '<div class="text-center text-xs text-gray-500 dark:text-gray-400">Weekend</div>' :
-            menuEntry ?
-                `<div class="text-center">
-                        <div class="text-xs font-medium text-teal-600 dark:text-teal-400 mb-1">${menuTypeName}</div>
-                        <div class="text-xs text-slate-700 dark:text-slate-300 line-clamp-3" title="${menuEntry.title}">${menuEntry.title}</div>
-                    </div>` :
-                '<div class="text-center text-xs text-slate-500 dark:text-slate-400">No menu</div>'
+        const dateLabel = index === 0
+            ? '<span class="tag-today">Today</span>'
+            : `${dayInfo.dayName} ${dayInfo.dayNumber} ${dayInfo.monthName}`;
+
+        let line;
+        if (isWeekend) {
+            line = '<span class="menu-dish menu-dish-muted">Weekend &mdash; the kitchen rests</span>';
+        } else if (menuEntry) {
+            line = `<span class="menu-dish" title="${menuEntry.title}">${menuEntry.title}</span>` +
+                '<span class="menu-leader"></span>' +
+                `<span class="menu-type">${menuTypeName}</span>`;
+        } else {
+            line = '<span class="menu-dish menu-dish-muted">No menu published yet</span>';
         }
+
+        row.innerHTML = `
+            <div class="menu-row-date">${dateLabel}</div>
+            <div class="menu-row-line">${line}</div>
         `;
 
-        previewContainer.appendChild(dayElement);
+        previewContainer.appendChild(row);
     });
 }
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ notifications.
 - 🚀 **Fast**: Blazor SSR with .NET 10 MapStaticAssets and clean architecture
 - 🔄 **Auto-Refresh**: Background service updates every 6 hours
 - 📱 **Universal**: Works with all calendar apps (Google Calendar, Outlook, Apple Calendar)
-- 🎨 **Responsive**: Modern UI with Tailwind CSS v4 and 7-day calendar preview
+- 🎨 **Responsive**: Printed menu-card inspired UI with Tailwind CSS v4 and a week-ahead preview
 - 🏗️ **Clean Architecture**: Separated Core, Infrastructure, and Web layers
 
 ## Quick Start


### PR DESCRIPTION
Replaces the generic teal/glassmorphism UI with a light, printed menu-card aesthetic: warm paper background with subtle grain, Fraunces and IBM Plex Mono typography, a single madder red accent, scotch-rule masthead, a dot-leader week-ahead list, and a clip-out dashed ticket for the feed URL. Dark mode is intentionally removed. All functionality is unchanged: mode toggle, per-day selects, live preview, URL params, alarm option, and copy. Admin pages inherit the theme through the shared card/button utilities.

Also fixes two calendar feed tests that had rotted because date windows were computed with DateTime.Today while the test fixture pins time to March 2026 via TestTimeZoneService. CalendarEndpointHandler and MenuScrapingService now use ITimeZoneService.GetCopenhagenDate(), and the static Nuxt parse chain takes an explicit today parameter so tests pass fixture dates. All 220 tests pass.